### PR TITLE
Update `mapbox_vector_tile.decode` call to v2.0 signature

### DIFF
--- a/vt2geojson/tools.py
+++ b/vt2geojson/tools.py
@@ -25,9 +25,9 @@ def vt_bytes_to_geojson(b_content: bytes, x: int, y: int, z: int, layer=None) ->
     :return: a features collection (GeoJSON).
     """
     try:
-        data = decode(b_content, y_coord_down=True)
-    except TypeError:
         data = decode(b_content, default_options={"y_coord_down": True})
+    except TypeError:
+        data = decode(b_content, y_coord_down=True)
     features_collections = [Layer(x=x, y=y, z=z, name=name, obj=layer_obj).toGeoJSON()
                             for name, layer_obj in data.items() if layer is None or name == layer]
     return {

--- a/vt2geojson/tools.py
+++ b/vt2geojson/tools.py
@@ -24,7 +24,10 @@ def vt_bytes_to_geojson(b_content: bytes, x: int, y: int, z: int, layer=None) ->
     :param layer: include only the specified layer.
     :return: a features collection (GeoJSON).
     """
-    data = decode(b_content, y_coord_down=True)
+    try:
+        data = decode(b_content, y_coord_down=True)
+    except TypeError:
+        data = decode(b_content, default_options={"y_coord_down": True})
     features_collections = [Layer(x=x, y=y, z=z, name=name, obj=layer_obj).toGeoJSON()
                             for name, layer_obj in data.items() if layer is None or name == layer]
     return {


### PR DESCRIPTION
Version 2.0.0 of mapbox_vector_tile was released Jan 16, and (sloppily) includes the breaking change that `y_coord_down` must now be passed inside the `default_options` dict argument. https://github.com/tilezen/mapbox-vector-tile/blob/master/mapbox_vector_tile/__init__.py#L4 This PR enables vt2geojson to support either.